### PR TITLE
Fix Zest_Sensor_P-T-RH shield path

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,8 @@ manifest:
       repo-path: zephyr_6tron-connector
       revision: 5594403822b9a258d168df22dd35aefa06344668
       path: 6tron/6tron_connector
-# ================== Zest_Core Boards ==================
+
+    # ================== Zest_Core Boards ==================
     - name: zest_core_fmlr-72
       repo-path: zephyr_zest-core-fmlr-72
       revision: f395bc4240cb2108ae485539bfcabcbb9d70396e
@@ -39,7 +40,8 @@ manifest:
       repo-path: zephyr_zest-core-stm32l562ve
       revision: 3258d7b0394d7dec20a9263dd4b6c22cfcf484df
       path: 6tron/boards/zest_core_stm32l562ve
-# ================= Integrated Devices =================
+
+    # ================= Integrated Devices =================
     - name: z_iaq
       repo-path: zephyr_z-iaq
       revision: 972051c8dafbf4ed1027eb16ff2c086bfa6a605b
@@ -48,7 +50,8 @@ manifest:
       repo-path: zephyr_z-motion
       revision: 385087b102bd032c369eff7d28bf969fe7332e81
       path: 6tron/boards/z_motion
-# ==================== Zest Shields =====================
+
+    # ==================== Zest Shields =====================
     - name: zest_interface_ethernet
       repo-path: zephyr_zest-interface-ethernet
       revision: 765c0029818806c1d7101b8a83ae57036d80744f
@@ -68,8 +71,9 @@ manifest:
     - name: zest_sensor_p-t-rh
       repo-path: zephyr_zest-sensor-p-t-rh
       revision: 51d37df1461e96700aba094f680adc9a45b969b5
-      path: 6tron/shields/zest-sensor_p_t-rh
-# ====================== Drivers =======================
+      path: 6tron/shields/zest_sensor_p-t-rh
+
+    # ====================== Drivers =======================
     - name: ams_as621x
       repo-path: zephyr_ams-as621x
       revision: a595722d26b1654b3caac2b2415f6ac73996a988


### PR DESCRIPTION
I also added blank lines to separate modules to increase readability.