### PR TITLE
Add zest_radio_wifi to the CI workflow

### DIFF
--- a/.github/workflows/check_manifest.yml
+++ b/.github/workflows/check_manifest.yml
@@ -102,6 +102,7 @@ jobs:
             zest_interface_rs485,
             zest_radio_gnss,
             zest_radio_lora868,
+            zest_radio_wifi,
             zest_rtc_rv-8803-c7,
             zest_sensor_imu,
             zest_sensor_p-t-rh,


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/check_manifest.yml` file. The change adds `zest_radio_wifi` to the list of jobs. 

* [`.github/workflows/check_manifest.yml`](diffhunk://#diff-074bcc3155bcfa54973eacfec59ed1ea85629e40860a93b02602547235923b99R105): Added `zest_radio_wifi` to the list of jobs.