### PR TITLE
Remove ams_as621x driver

### DIFF
--- a/.github/workflows/check_manifest.yml
+++ b/.github/workflows/check_manifest.yml
@@ -347,13 +347,6 @@ jobs:
         with:
           personal_access_token: ${{ secrets.CI_6TRON_ZEPHYR_RO }}
 
-      - name: AMS AS621x
-        uses: catie-aq/zephyr_workflows/zephyr_twister@main
-        if: always()
-        with:
-          path: 6tron/drivers/ams_as621x/samples
-          options: ${{ env.TWISTER_OPTIONS }}
-
       - name: Bosch BNO055
         uses: catie-aq/zephyr_workflows/zephyr_twister@main
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Remove AMS AS621x driver (now supported in Zephyr OS).
+
 ## [4.1.0+202505] - 20250523
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ in the [6TRON](https://6tron.io) project.
 
 ## Drivers
 
-- [AMS AS621X](https://github.com/catie-aq/zephyr_ams-as621x)
 - [Bosch BNO055](https://github.com/catie-aq/zephyr_bosch-bno055)
 - [Honeywell HPMA115](https://github.com/catie-aq/zephyr_honeywell-hpma115)
 - [ILITEK ILI9163C](https://github.com/catie-aq/zephyr_ilitek-ili9163c)

--- a/west.yml
+++ b/west.yml
@@ -114,10 +114,6 @@ manifest:
       path: 6tron/shields/zest_storage_microsd
 
     # ====================== Drivers =======================
-    - name: ams_as621x
-      repo-path: zephyr_ams-as621x
-      revision: 096219be378848cb9a319b27095b5db6ce2f5fac
-      path: 6tron/drivers/ams_as621x
     - name: bosch_bno055
       repo-path: zephyr_bosch-bno055
       revision: 48210fbc515c54570ce8dbc3d6d58edc07a8268f


### PR DESCRIPTION
This pull request removes the `ams_as621x` driver from the manifest file.
Cf: https://github.com/zephyrproject-rtos/zephyr/commit/b921db6608bb779d16dba6b8b73b6c033f143cbb

> [!NOTE]  
> This driver is now supported on Zephyr 0S: [AS6212 Driver](https://docs.zephyrproject.org/3.7.0/build/dts/api/bindings/sensor/ams%2Cas6212.html)