### PR TITLE
Remove Sensirion SCD4X driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Remove Sensirion SCD4X driver (now supported in Zephyr OS).
+
 ## [4.2.0+202508] - 20250829
 
 ### Removed

--- a/west.yml
+++ b/west.yml
@@ -146,10 +146,6 @@ manifest:
       repo-path: zephyr_quectel-l86
       revision: 96efc31c70890de20218fce76bbe26d4a603e05b
       path: 6tron/drivers/quectel_l86
-    - name: sensirion_scd4x
-      repo-path: zephyr_sensirion-scd4x
-      revision: 3688d44c051071e721a08f4ce4ea8caa778eb62b
-      path: 6tron/drivers/sensirion_scd4x
     - name: te-connectivity_htu21d
       repo-path: zephyr_te-connectivity-htu21d
       revision: cb10ac462907403ba2fcbc6289c80ecf59e1d302


### PR DESCRIPTION
This pull request removes the `sensirion_scd4x` driver from the manifest file.

> [!NOTE]  
> This driver is now supported on Zephyr 0S: [SCD4x Driver](https://docs.zephyrproject.org/latest/build/dts/api/bindings/sensor/sensirion%2Cscd41.html)